### PR TITLE
【追加】レストランテーブル、フードテーブルに初期データを投入

### DIFF
--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -5,8 +5,20 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-Issue.create([
-               { name: '点' },
-               { name: '線' },
-               { name: '面' }
-             ])
+3.times do |n|
+  restaurant = Restaurant.new(
+    name: "うまいレストラン_#{n}",
+    fee: 100,
+    time_required: 10,
+  )
+
+  12.times do |m|
+    restaurant.foods.build(
+      name: "うますぎる商品_#{m}",
+      price: 500,
+      description: "フード_#{m}の説明文です。"
+    )
+  end
+
+  restaurant.save!
+end


### PR DESCRIPTION

## 変更の概要
レストランテーブル、フードテーブルに初期データを投入

### 関連するissue 
関連するissue #10

## なぜこの変更をするのか

レストラン一覧を表示するページ、そのレストランに関連する料理に関するページが初期から必要であるから

## やったこと

`api/db/seed.rb`の編集

## 変更内容


**api/db/seed.rb**
```ruby
3.times do |n|
  restaurant = Restaurant.new(
    name: "うまいレストラン_#{n}",
    fee: 100,
    time_required: 10,
  )

  12.times do |m|
    restaurant.foods.build(
      name: "うますぎる商品_#{m}",
      price: 500,
      description: "フード_#{m}の説明文です。"
    )
  end

  restaurant.save!
end
```

## 影響範囲

* ユーザに影響すること
* メンバーに影響すること
* システムに影響すること

## どうやるのか

* 使い方
* 再現手順

## 課題

* 悩んでいること
* とくにレビューしてほしいところ

## 備考

* その他に伝えたいこと
