### PR TITLE
【追加】仮注文を保存する処理をフードコントローラーに記述

### DIFF
--- a/api/app/controllers/api/v1/line_foods_controller.rb
+++ b/api/app/controllers/api/v1/line_foods_controller.rb
@@ -1,0 +1,48 @@
+module Api
+  module V1
+    class LineFoodsController < ApplicationController
+      before_action :set_food, only: %i[create]
+
+      def create
+        if LineFood.active.other_restaurant(@ordered_food.restaurant.id).exists?
+          return render json: {
+            existing_restaurant: LineFood.other_restaurant(@ordered_food.restaurant.id).first.restaurant.name,
+            new_restaurant: Food.find(params[:food_id]).restaurant.name,
+          }, status: :not_acceptable
+        end
+
+        set_line_food(@ordered_food)
+
+        if @line_food.save
+          render json: {
+            line_food: @line_food
+          }, status: :created
+        else
+          render json: {}, status: :internal_server_error
+        end
+      end
+
+      private
+
+      def set_food
+        @ordered_food = Food.find(params[:food_id])
+      end
+
+      def set_line_food(ordered_food)
+        if ordered_food.line_food.present?
+          @line_food = ordered_food.line_food
+          @line_food.attributes = {
+            count: ordered_food.line_food.count + params[:count],
+            active: true
+          }
+        else
+          @line_food = ordered_food.build_line_food(
+            count: params[:count],
+            restaurant: ordered_food.restaurant,
+            active: true
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION


## 変更の概要

### 関連するissue 

close Issue #16

## なぜこの変更をするのか

料理をカートに入れた際、そのデータを仮注文として保存する必要があるから。

## やったこと

`line_food_controller.rb`の編集

1. すでに他店舗の仮注文が存在する場合406 Not Acceptableを返す処理を記述。

2. 前回の同じ商品の仮注文が存在する場合、注文の個数を変換。さらに、前回の注文データが残っていてactiveがfalseになっている可能性があるのでtrueにする処理を記述。

3. 前回に仮注文がない場合、数量、料理が紐づくレストランのID、そして`active`を`true`にして保存 

最後に仮注文の保存が完了したら、その仮注文を返す処理を記述


## 変更内容

`curl -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d '{"food_id": 4, "count": 5}' http://localhost/api/v1/line_foods -v`の結果

<img width="600" alt="スクリーンショット 2021-12-12 0 49 42" src="https://user-images.githubusercontent.com/71915489/145682788-4394392c-1cf4-4977-a9ef-45679138be44.png">


## 影響範囲

* ユーザに影響すること
* メンバーに影響すること
* システムに影響すること

## どうやるのか

* 使い方
* 再現手順

## 課題

* 悩んでいること
* とくにレビューしてほしいところ

## 備考

* その他に伝えたいこと
