### PR TITLE
【追加】仮注文のコントローラーに、仮注文の一覧を取得するメソッドを作成

### DIFF
--- a/api/app/controllers/api/v1/line_foods_controller.rb
+++ b/api/app/controllers/api/v1/line_foods_controller.rb
@@ -3,6 +3,21 @@ module Api
     class LineFoodsController < ApplicationController
       before_action :set_food, only: %i[create]
 
+      def index
+        line_foods = LineFood.active
+        if line_foods.exists?
+          render json: {
+            line_food_ids: line_foods.map { |line_food| line_food.id },
+            #違う店舗のline_foodが同時に存在することはないのでline_foods[0]で良い。
+            restaurant: line_foods[0].restaurant,
+            count: line_foods.sum { |line_food| line_food[:count] },
+            amount: line_foods.sum { |line_food| line_food.total_amount },
+          }, status: :ok
+        else
+          render json: {}, status: :no_content
+        end
+      end
+
       def create
         if LineFood.active.other_restaurant(@ordered_food.restaurant.id).exists?
           return render json: {


### PR DESCRIPTION

関連issue #18

## 変更の概要

現在の仮注文の状態を見れるようにする

### 関連するissue 

close #18

## なぜこの変更をするのか

現在の仮注文の状態を見れるようにする必要がある。

## やったこと

`line_food_controller.rb`を編集して`index`アクションを追加


## 変更内容
### 実行したコマンド
`curl -X GET "http://localhost/api/v1/line_foods" -v`

### 実行結果

**データがないとき**


<img width="523" alt="スクリーンショット 2021-12-12 1 33 14" src="https://user-images.githubusercontent.com/71915489/145684271-be520fbc-99bc-43d3-b18c-c892d07976c4.png">

**データが存在するとき**


<img width="700" alt="スクリーンショット 2021-12-12 1 43 16" src="https://user-images.githubusercontent.com/71915489/145684604-29ef4841-0b4f-4b6b-a6cf-1c71c315ba21.png">




## 影響範囲

* ユーザに影響すること
* メンバーに影響すること
* システムに影響すること

## どうやるのか

* 使い方
* 再現手順

## 課題

* 悩んでいること
* とくにレビューしてほしいところ

## 備考

* その他に伝えたいこと
