### PR TITLE
【追加】すでに他の店舗の仮注文が存在する場合、その仮注文を論理削除するメソッドを追加

### DIFF
--- a/api/app/controllers/api/v1/line_foods_controller.rb
+++ b/api/app/controllers/api/v1/line_foods_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class LineFoodsController < ApplicationController
-      before_action :set_food, only: %i[create]
+      before_action :set_food, only: %i[create replace]
 
       def index
         line_foods = LineFood.active
@@ -24,6 +24,22 @@ module Api
             existing_restaurant: LineFood.other_restaurant(@ordered_food.restaurant.id).first.restaurant.name,
             new_restaurant: Food.find(params[:food_id]).restaurant.name,
           }, status: :not_acceptable
+        end
+
+        set_line_food(@ordered_food)
+
+        if @line_food.save
+          render json: {
+            line_food: @line_food
+          }, status: :created
+        else
+          render json: {}, status: :internal_server_error
+        end
+      end
+
+      def replace
+        LineFood.active.other_restaurant(@ordered_food.restaurant.id).each do |line_food|
+          line_food.update_attribute(:active, false)
         end
 
         set_line_food(@ordered_food)


### PR DESCRIPTION



## 変更の概要
すでに他の店舗の仮注文が存在する場合、その仮注文を論理削除するメソッドを追加

### 関連するissue 

close #20

## なぜこの変更をするのか

今回、ウーバーイーツを想定しているため、複数店舗の注文を同時にできないようにする必要がある

## やったこと

`line_food_controller.rb`にreplaceアクションを追加する。


## 変更内容

現在`restaurnt_id`が`1`の仮注文が存在するが`restaurnt_id`が`2`の仮注文を`curl`コマンドを使って送信した。

### 実行したコマンド
`curl -H "Accept: application/json" -H "Content-Type: application/json" -X PUT -d '{"food_id": 17, "count": 3}' http://localhost/api/v1/line_foods/replace -v`

### 結果
新たな`line_food`が保存されている。
<img width="700" alt="スクリーンショット 2021-12-12 2 20 07" src="https://user-images.githubusercontent.com/71915489/145685691-3c403a6a-01e8-439c-89f5-0e712c0d640c.png">

さらに`curl -X GET "http://localhost/api/v1/restaurants/1/foods" -v`を実行することによって`restaurnt_id`が`2`の仮注文のみが表示され、`restaurnt_id`が`1`の仮注文が表示されていないことがわかる。

<img width="700" alt="スクリーンショット 2021-12-12 2 32 02" src="https://user-images.githubusercontent.com/71915489/145686012-a6e2d580-7908-48e2-a883-7eaf25b3bed6.png">


これは`index`は`active`が`true`の仮注文のみ返していることになる。

すなわち他店舗の仮注文が存在した場合、古い注文を論理削除する処理が成功している。



## 影響範囲

* ユーザに影響すること
* メンバーに影響すること
* システムに影響すること

## どうやるのか

* 使い方
* 再現手順

## 課題

* 悩んでいること
* とくにレビューしてほしいところ

## 備考

* その他に伝えたいこと
