### PR TITLE
【追加】本注文を保存するコントローラーを追加

### DIFF
--- a/api/app/controllers/api/v1/orders_controller.rb
+++ b/api/app/controllers/api/v1/orders_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    class OrdersController < ApplicationController
+      def create
+        posted_line_foods = LineFood.where(id: params[:line_food_ids])
+        order = Order.new(
+          total_price: total_price(posted_line_foods),
+        )
+        if order.save_with_update_line_foods!(posted_line_foods)
+          render json: {}, status: :no_content
+        else
+          render json: {}, status: :internal_server_error
+        end
+      end
+
+      private
+
+      def total_price(posted_line_foods)
+        posted_line_foods.sum {|line_food| line_food.total_amount } + posted_line_foods.first.restaurant.fee
+      end
+    end
+  end
+end


### PR DESCRIPTION


関連するIssue #22

## 変更の概要
orders_controller.rbのcreateアクションに本注文を保存するcreateアクションを追加する。
### 関連するissue 
close #22
## なぜこの変更をするのか

カートに入れるによって仮注文が完了した後に本注文を完了させる必要があるから。

## やったこと


具体的には

注文の合計金額を算出

そしてトランザクション内で、本注文のidが仮注文のorder_idになるように更新し、本注文を保存する。
この二つの処理は必ずどちらも成功するようにする。


## 変更内容

保留

## 影響範囲

* ユーザに影響すること
* メンバーに影響すること
* システムに影響すること

## どうやるのか

* 使い方
* 再現手順

## 課題

* 悩んでいること
* とくにレビューしてほしいところ

## 備考

* その他に伝えたいこと
